### PR TITLE
Add ability to update attendance

### DIFF
--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -58,6 +58,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
     private val CALENDAR_COLOR_ARGUMENT = "calendarColor"
     private val LOCAL_ACCOUNT_NAME_ARGUMENT = "localAccountName"
     private val EVENT_AVAILABILITY_ARGUMENT = "availability"
+    private val ATTENDANCE_STATUS_ARGUMENT = "attendanceStatus"
 
 
     private lateinit var _registrar: Registrar
@@ -164,7 +165,8 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                         attendeeArgs[EMAIL_ADDRESS_ARGUMENT] as String,
                         attendeeArgs[NAME_ARGUMENT] as String?,
                         attendeeArgs[ROLE_ARGUMENT] as Int,
-                        null, null, null))
+                        attendeeArgs[ATTENDANCE_STATUS_ARGUMENT] as Int?,
+                        null, null))
             }
         }
 

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -164,7 +164,7 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                         attendeeArgs[EMAIL_ADDRESS_ARGUMENT] as String,
                         attendeeArgs[NAME_ARGUMENT] as String?,
                         attendeeArgs[ROLE_ARGUMENT] as Int,
-                        null, null))
+                        null, null, null))
             }
         }
 

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Attendee.kt
@@ -1,3 +1,3 @@
 package com.builttoroam.devicecalendar.models
 
-class Attendee(val emailAddress: String, val name: String?, val role: Int, val attendanceStatus: Int?, val isOrganizer: Boolean?)
+class Attendee(val emailAddress: String, val name: String?, val role: Int, val attendanceStatus: Int?, val isOrganizer: Boolean?, val isCurrentUser: Boolean?)

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Calendar.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Calendar.kt
@@ -1,6 +1,6 @@
 package com.builttoroam.devicecalendar.models
 
-class Calendar(val id: String, val name: String, val color : Int, val accountName: String, val accountType: String) {
+class Calendar(val id: String, val name: String, val color : Int, val accountName: String, val accountType: String, val ownerAccount: String) {
     var isReadOnly: Boolean = false
     var isDefault: Boolean = false
 }

--- a/lib/device_calendar.dart
+++ b/lib/device_calendar.dart
@@ -10,5 +10,7 @@ export 'src/models/event.dart';
 export 'src/models/retrieve_events_params.dart';
 export 'src/models/recurrence_rule.dart';
 export 'src/models/platform_specifics/ios/attendee_details.dart';
+export 'src/models/platform_specifics/ios/attendance_status.dart';
 export 'src/models/platform_specifics/android/attendee_details.dart';
+export 'src/models/platform_specifics/android/attendance_status.dart';
 export 'src/device_calendar.dart';

--- a/lib/src/models/attendee.dart
+++ b/lib/src/models/attendee.dart
@@ -19,6 +19,9 @@ class Attendee {
   /// Read-only. Returns true if the attendee is an organiser, else false
   bool isOrganiser = false;
 
+  /// Read-only. Returns true if the attendee is the current user, else false
+  bool isCurrentUser = false;
+
   /// Details about the attendee that are specific to iOS.
   /// When reading details for an existing event, this will only be populated on iOS devices.
   IosAttendeeDetails iosAttendeeDetails;
@@ -33,7 +36,8 @@ class Attendee {
       this.role,
       this.isOrganiser = false,
       this.iosAttendeeDetails,
-      this.androidAttendeeDetails});
+      this.androidAttendeeDetails,
+      this.isCurrentUser});
 
   Attendee.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -43,6 +47,7 @@ class Attendee {
     name = json['name'];
     emailAddress = json['emailAddress'];
     role = AttendeeRole.values[json['role'] ?? 0];
+    isCurrentUser = json['isCurrentUser'];
 
     if (Platform.isAndroid) {
       isOrganiser =

--- a/lib/src/models/platform_specifics/android/attendee_details.dart
+++ b/lib/src/models/platform_specifics/android/attendee_details.dart
@@ -5,15 +5,12 @@ import '../../../common/error_messages.dart';
 import 'attendance_status.dart';
 
 class AndroidAttendeeDetails {
-  AndroidAttendanceStatus _attendanceStatus;
-
   /// An attendee role: None, Optional, Required or Resource
   AttendeeRole role;
 
-  /// The attendee's status for the event. This is read-only
-  AndroidAttendanceStatus get attendanceStatus => _attendanceStatus;
+  AndroidAttendanceStatus attendanceStatus;
 
-  AndroidAttendeeDetails({@required this.role});
+  AndroidAttendeeDetails({@required this.role, this.attendanceStatus});
 
   AndroidAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -23,12 +20,15 @@ class AndroidAttendeeDetails {
     role = AttendeeRole.values[json['role']];
 
     if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
-      _attendanceStatus =
+      attendanceStatus =
           AndroidAttendanceStatus.values[json['attendanceStatus']];
     }
   }
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{'role': role?.index};
+    return <String, dynamic>{
+      'role': role?.index,
+      'attendanceStatus': attendanceStatus?.index
+    };
   }
 }

--- a/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -3,15 +3,13 @@ import '../../../common/error_messages.dart';
 import 'attendance_status.dart';
 
 class IosAttendeeDetails {
-  IosAttendanceStatus _attendanceStatus;
+  IosAttendanceStatus attendanceStatus;
 
   /// An attendee role: None, Optional, Required or Resource
   AttendeeRole role;
 
-  /// The attendee's status for the event. This is read-only
-  IosAttendanceStatus get attendanceStatus => _attendanceStatus;
 
-  IosAttendeeDetails({this.role});
+  IosAttendeeDetails({this.role, this.attendanceStatus});
 
   IosAttendeeDetails.fromJson(Map<String, dynamic> json) {
     if (json == null) {
@@ -21,7 +19,7 @@ class IosAttendeeDetails {
     role = AttendeeRole.values[json['role']];
 
     if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
-      _attendanceStatus = IosAttendanceStatus.values[json['attendanceStatus']];
+      attendanceStatus = IosAttendanceStatus.values[json['attendanceStatus']];
     }
   }
 


### PR DESCRIPTION
What this PR does:

* It adds `isCurrentUser` to Attendee. This allows us to detect current user's attendance of the event
* It commits attendance status from current user's Attendance object to device's calendar database when calling `createOrUpdateEvent`

This is Android only (I do not have a Mac to compile iOS part nor do I have iOS device to test this). But I think iOS part should not be that difficult, at least first point only involves directly exposing a boolean: https://developer.apple.com/documentation/eventkit/ekparticipant/1507248-iscurrentuser