### PR TITLE
iOS Source fallbacks and re-add url parameter

### DIFF
--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -56,6 +56,7 @@ class Event {
       this.attendees,
       this.recurrenceRule,
       this.reminders,
+      this.url,
       required this.availability,
       this.allDay = false});
 


### PR DESCRIPTION
I should have separated these into two pull requests but I believe they are both worthwhile fixes; if you disagree about the source fallbacks then it would be great if you could at least re-add the url parameter.

In production I'm seeing errors and a failure to create scheduled notifications on many devices, as it seems in more recent iOS versions there is often no local calendar. It would be even better if there were a way to query sources directly from flutter, but that would complicate things and is probably overkill in most cases - I'm going to guess that 99% of users just use the default iCloud calendar.