### PR TITLE
Make timezone database initialization optional

### DIFF
--- a/lib/src/device_calendar.dart
+++ b/lib/src/device_calendar.dart
@@ -24,8 +24,10 @@ class DeviceCalendarPlugin {
 
   static final DeviceCalendarPlugin _instance = DeviceCalendarPlugin.private();
 
-  factory DeviceCalendarPlugin() {
-    tz.initializeTimeZones();
+  factory DeviceCalendarPlugin({bool shouldInitTimezone = true}) {
+    if (shouldInitTimezone) {
+      tz.initializeTimeZones();
+    }
     return _instance;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   collection: ^1.15.0
   sprintf: ^6.0.0
   timezone: ^0.7.0
-  flutter_native_timezone: ^1.0.10
+  flutter_native_timezone: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1. In case the application initializes its own timezone by setting the local timezone as the current device timezone, it should be possible to omit the initialization of the timezone database so that it doesn't default to UTC.
2. Update `flutter_native_timezone` library to the latest 2.0.0 version.
 