### PR TITLE
Event.fromJson 'start'-key assignment fixed

### DIFF
--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -69,7 +69,7 @@ class Event {
     title = json['title'];
     description = json['description'];
 
-    final int? startTimestamp = json['start'];
+    final int? startTimestamp = json['eventStartDate'];
     final String? startLocationName = json['startTimeZone'];
     var startTimeZone = timeZoneDatabase.locations[startLocationName];
     startTimeZone ??= local;
@@ -77,7 +77,7 @@ class Event {
         ? TZDateTime.fromMillisecondsSinceEpoch(startTimeZone, startTimestamp)
         : TZDateTime.now(local);
 
-    final int? endTimestamp = json['end'];
+    final int? endTimestamp = json['eventEndDate'];
     final String? endLocationName = json['endTimeZone'];
     var endLocation = timeZoneDatabase.locations[endLocationName];
     endLocation ??= local;


### PR DESCRIPTION
Changed key names to 'eventStartDate' and 'eventEndDate'.

Fix for #315