### PR TITLE
pub cache location fix

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ jobs:
           sed  -i "s/version.*/&-$GITHUB_RUN_ID/" pubspec.yaml
       - name: Fetch credentials for publish
         run: |
-          content=`cat ~/.pub-cache/credentials.json`
+          content= "cat $PUB_CACHE/credentials.json"
       - name: Publish package
         uses: sakebook/actions-flutter-pub-publisher@v1.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: flutter --version
       - name: Fetch credentials for publish
         run: |
-          content=`cat ~/.pub-cache/credentials.json`
+          content= "cat $PUB_CACHE/credentials.json"
       - name: Publish package
         uses: sakebook/actions-flutter-pub-publisher@v1.3.1
         with:


### PR DESCRIPTION
Continuing #346 

With this fix we should be able to locate the credentials.

Unless it isn't there, which maybe we should need to set the credentials into Github's env secrets.