### PR TITLE
Set default Availability to Busy, and minor fixes

### DIFF
--- a/example/lib/presentation/date_time_picker.dart
+++ b/example/lib/presentation/date_time_picker.dart
@@ -31,8 +31,9 @@ class DateTimePicker extends StatelessWidget {
             : DateTime.now(),
         firstDate: DateTime(2015, 8),
         lastDate: DateTime(2101));
-    if (picked != null && picked != selectedDate && selectDate != null)
+    if (picked != null && picked != selectedDate && selectDate != null) {
       selectDate!(picked);
+    }
   }
 
   Future<Null> _selectTime(BuildContext context) async {

--- a/example/lib/presentation/event_item.dart
+++ b/example/lib/presentation/event_item.dart
@@ -45,8 +45,9 @@ class _EventItemState extends State<EventItem> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        if (widget._calendarEvent != null)
+        if (widget._calendarEvent != null) {
           widget._onTapped(widget._calendarEvent as Event);
+        }
       },
       child: Card(
         child: Column(
@@ -200,7 +201,7 @@ class _EventItemState extends State<EventItem> {
                         ),
                         Expanded(
                           child: Text(
-                            widget._calendarEvent?.availability?.enumToString ??
+                            widget._calendarEvent?.availability.enumToString ??
                                 '',
                             overflow: TextOverflow.ellipsis,
                           ),
@@ -216,8 +217,9 @@ class _EventItemState extends State<EventItem> {
                 if (!widget._isReadOnly) ...[
                   IconButton(
                     onPressed: () {
-                      if (widget._calendarEvent != null)
+                      if (widget._calendarEvent != null) {
                         widget._onTapped(widget._calendarEvent as Event);
+                      }
                     },
                     icon: Icon(Icons.edit),
                   ),
@@ -256,8 +258,9 @@ class _EventItemState extends State<EventItem> {
                               ],
                             );
                           } else {
-                            if (widget._calendarEvent == null)
+                            if (widget._calendarEvent == null) {
                               return SizedBox();
+                            }
                             return RecurringEventDialog(
                                 widget._deviceCalendarPlugin,
                                 widget._calendarEvent!,
@@ -272,8 +275,9 @@ class _EventItemState extends State<EventItem> {
                 ] else ...[
                   IconButton(
                     onPressed: () {
-                      if (widget._calendarEvent != null)
+                      if (widget._calendarEvent != null) {
                         widget._onTapped(widget._calendarEvent!);
+                      }
                     },
                     icon: Icon(Icons.remove_red_eye),
                   ),

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -94,8 +94,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         _startDate = TZDateTime.now(fallbackLocation!);
         _endDate = TZDateTime.now(fallbackLocation).add(Duration(hours: 1));
       }
-      _event = Event(_calendar.id,
-          start: _startDate, end: _endDate, availability: Availability.Busy);
+      _event = Event(_calendar.id, start: _startDate, end: _endDate);
 
       print('DeviceCalendarPlugin calendar id is: ${_calendar.id}');
 

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -136,7 +136,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
             _event?.recurrenceRule?.monthOfYear ?? MonthOfYear.January;
         _weekOfMonth = _event?.recurrenceRule?.weekOfMonth ?? WeekNumber.First;
         _selectedDayOfWeek =
-        _daysOfWeek.isNotEmpty ? _daysOfWeek.first : DayOfWeek.Monday;
+            _daysOfWeek.isNotEmpty ? _daysOfWeek.first : DayOfWeek.Monday;
         _dayOfMonth = _event?.recurrenceRule?.dayOfMonth ?? 1;
 
         if (_daysOfWeek.isNotEmpty) {
@@ -513,8 +513,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                 validator: _validateInterval,
                                 textAlign: TextAlign.right,
                                 onSaved: (String? value) {
-                                  if (value != null)
+                                  if (value != null) {
                                     _interval = int.tryParse(value);
+                                  }
                                 },
                               ),
                             ),
@@ -738,8 +739,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                   validator: _validateTotalOccurrences,
                                   textAlign: TextAlign.right,
                                   onSaved: (String? value) {
-                                    if (value != null)
+                                    if (value != null) {
                                       _totalOccurrences = int.tryParse(value);
+                                    }
                                   },
                                 ),
                               ),
@@ -816,8 +818,9 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                         _recurrenceFrequency == RecurrenceFrequency.Yearly)) {
                   // Setting day of the week parameters for WeekNumber to avoid clashing with the weekly recurrence values
                   _daysOfWeek.clear();
-                  if (_selectedDayOfWeek != null)
+                  if (_selectedDayOfWeek != null) {
                     _daysOfWeek.add(_selectedDayOfWeek as DayOfWeek);
+                  }
                 } else {
                   _weekOfMonth = null;
                 }

--- a/example/lib/presentation/recurring_event_dialog.dart
+++ b/example/lib/presentation/recurring_event_dialog.dart
@@ -51,9 +51,10 @@ class _RecurringEventDialogState extends State<RecurringEventDialog> {
                     _calendarEvent.start?.millisecondsSinceEpoch,
                     _calendarEvent.end?.millisecondsSinceEpoch,
                     false);
-            if (_onDeleteFinished != null)
+            if (_onDeleteFinished != null) {
               _onDeleteFinished!(
                   deleteResult.isSuccess && deleteResult.data != null);
+            }
           },
           child: Text('This instance only'),
         ),
@@ -68,9 +69,10 @@ class _RecurringEventDialogState extends State<RecurringEventDialog> {
                     _calendarEvent.start?.millisecondsSinceEpoch,
                     _calendarEvent.end?.millisecondsSinceEpoch,
                     true);
-            if (_onDeleteFinished != null)
+            if (_onDeleteFinished != null) {
               _onDeleteFinished!(
                   deleteResult.isSuccess && deleteResult.data != null);
+            }
           },
           child: Text('This and following instances'),
         ),
@@ -80,9 +82,10 @@ class _RecurringEventDialogState extends State<RecurringEventDialog> {
             if (_onLoadingStarted != null) _onLoadingStarted!();
             final deleteResult = await _deviceCalendarPlugin.deleteEvent(
                 _calendarEvent.calendarId, _calendarEvent.eventId);
-            if (_onDeleteFinished != null)
+            if (_onDeleteFinished != null) {
               _onDeleteFinished!(
                   deleteResult.isSuccess && deleteResult.data != null);
+            }
           },
           child: Text('All instances'),
         ),

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -56,7 +56,7 @@ class Event {
       this.attendees,
       this.recurrenceRule,
       this.reminders,
-      required this.availability,
+      this.availability = Availability.Busy,
       this.location,
       this.url,
       this.allDay = false});

--- a/lib/src/models/platform_specifics/android/attendee_details.dart
+++ b/lib/src/models/platform_specifics/android/attendee_details.dart
@@ -14,16 +14,13 @@ class AndroidAttendeeDetails {
       throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
 
-    if (json['attendanceStatus'] != null &&
-        json['attendanceStatus'] is int) {
+    if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
       _attendanceStatus =
           AndroidAttendanceStatus.values[json['attendanceStatus']];
     }
   }
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'attendanceStatus': _attendanceStatus?.index
-    };
+    return <String, dynamic>{'attendanceStatus': _attendanceStatus?.index};
   }
 }

--- a/lib/src/models/platform_specifics/ios/attendee_details.dart
+++ b/lib/src/models/platform_specifics/ios/attendee_details.dart
@@ -14,10 +14,8 @@ class IosAttendeeDetails {
       throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
 
-    if (json['attendanceStatus'] != null &&
-        json['attendanceStatus'] is int) {
-      _attendanceStatus =
-          IosAttendanceStatus.values[json['attendanceStatus']];
+    if (json['attendanceStatus'] != null && json['attendanceStatus'] is int) {
+      _attendanceStatus = IosAttendanceStatus.values[json['attendanceStatus']];
     }
   }
 

--- a/test/device_calendar_test.dart
+++ b/test/device_calendar_test.dart
@@ -64,7 +64,8 @@ void main() {
     final String? calendarId = null;
     final params = RetrieveEventsParams();
 
-    final result = await deviceCalendarPlugin.retrieveEvents(calendarId, params);
+    final result =
+        await deviceCalendarPlugin.retrieveEvents(calendarId, params);
     expect(result.isSuccess, false);
     expect(result.errors.length, greaterThan(0));
     expect(result.errors[0].errorCode, equals(ErrorCodes.invalidArguments));

--- a/test/device_calendar_test.dart
+++ b/test/device_calendar_test.dart
@@ -105,7 +105,7 @@ void main() {
 
   test('CreateEvent_Arguments_Invalid', () async {
     final String? fakeCalendarId = null;
-    final event = Event(fakeCalendarId, availability: Availability.Busy);
+    final event = Event(fakeCalendarId);
 
     final result = await deviceCalendarPlugin.createOrUpdateEvent(event);
     expect(result!.isSuccess, false);
@@ -120,7 +120,7 @@ void main() {
     });
 
     final fakeCalendarId = 'fakeCalendarId';
-    final event = Event(fakeCalendarId, availability: Availability.Busy);
+    final event = Event(fakeCalendarId);
     event.title = 'fakeEventTitle';
     event.start = TZDateTime.now(local);
     event.end = event.start!.add(Duration(hours: 1));
@@ -144,7 +144,7 @@ void main() {
     });
 
     final fakeCalendarId = 'fakeCalendarId';
-    final event = Event(fakeCalendarId, availability: Availability.Busy);
+    final event = Event(fakeCalendarId);
     event.eventId = 'fakeEventId';
     event.title = 'fakeEventTitle';
     event.start = TZDateTime.now(local);
@@ -176,8 +176,16 @@ void main() {
   });
 
   test('Event_Serialises_Correctly', () async {
-    final event = Event('calendarId',eventId: 'eventId',start: TZDateTime(
-      timeZoneDatabase.locations.entries.skip(20).first.value, 1980, 10,1,0,0,0), availability: Availability.Busy);
+    final event = Event('calendarId',
+        eventId: 'eventId',
+        start: TZDateTime(
+            timeZoneDatabase.locations.entries.skip(20).first.value,
+            1980,
+            10,
+            1,
+            0,
+            0,
+            0));
     final stringEvent = event.toJson();
     expect(stringEvent, isNotNull);
     final newEvent = Event.fromJson(stringEvent);


### PR DESCRIPTION
- `Availability` now default to busy if you don't have one, also makes it not `required`. 
 ie. Less code need to be edited when upgrading to v4.

- Other formatting and warning fixes as prompted by flutter's checks

Since this benefits migration from previous versions I hope to merge this before v4 main release.