### PR TITLE
Emergency fix: not getting times from events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- To benefit from the current changelog reader in CI/CD, please follow the changelog format from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). -->
 
+## [4.0.1](https://github.com/builttoroam/device_calendar/releases/tag/4.1.0)
+
+- Fixes event time retrieved
+
 ## [4.0.0](https://github.com/builttoroam/device_calendar/releases/tag/4.0.0)
 
 - Timezone plugin and logic implemented. All issues related to timezone shoulde be fixed.

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -471,7 +471,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
 
         if (event.allDay) {
             val calendar = java.util.Calendar.getInstance()
-            calendar.timeInMillis = event.start!!
+            calendar.timeInMillis = event.eventStartDate!!
             calendar.set(java.util.Calendar.HOUR, 0)
             calendar.set(java.util.Calendar.MINUTE, 0)
             calendar.set(java.util.Calendar.SECOND, 0)
@@ -481,10 +481,10 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
             values.put(Events.DTEND, calendar.timeInMillis)
             values.put(Events.EVENT_TIMEZONE, getTimeZone(event.startTimeZone).id)
         } else {
-            values.put(Events.DTSTART, event.start!!)
+            values.put(Events.DTSTART, event.eventStartDate!!)
             values.put(Events.EVENT_TIMEZONE, getTimeZone(event.startTimeZone).id)
 
-            values.put(Events.DTEND, event.end!!)
+            values.put(Events.DTEND, event.eventEndDate!!)
             values.put(Events.EVENT_END_TIMEZONE, getTimeZone(event.endTimeZone).id)
         }
         values.put(Events.TITLE, event.title)
@@ -717,8 +717,8 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         event.eventId = eventId.toString()
         event.calendarId = calendarId
         event.description = description
-        event.start = begin
-        event.end = end
+        event.eventStartDate = begin
+        event.eventEndDate = end
         event.allDay = allDay
         event.location = location
         event.url = url

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -169,8 +169,8 @@ class DeviceCalendarPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware {
         event.eventId = call.argument<String>(EVENT_ID_ARGUMENT)
         event.description = call.argument<String>(EVENT_DESCRIPTION_ARGUMENT)
         event.allDay = call.argument<Boolean>(EVENT_ALL_DAY_ARGUMENT) ?: false
-        event.start = call.argument<Long>(EVENT_START_DATE_ARGUMENT)!!
-        event.end = call.argument<Long>(EVENT_END_DATE_ARGUMENT)!!
+        event.eventStartDate = call.argument<Long>(EVENT_START_DATE_ARGUMENT)!!
+        event.eventEndDate = call.argument<Long>(EVENT_END_DATE_ARGUMENT)!!
         event.startTimeZone = call.argument<String>(EVENT_START_TIMEZONE_ARGUMENT)
         event.endTimeZone = call.argument<String>(EVENT_END_TIMEZONE_ARGUMENT)
         event.location = call.argument<String>(EVENT_LOCATION_ARGUMENT)

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -6,8 +6,8 @@ class Event {
     var eventId: String? = null
     var calendarId: String? = null
     var description: String? = null
-    var start: Long? = null
-    var end: Long? = null
+    var eventStartDate: Long? = null
+    var eventEndDate: Long? = null
     var startTimeZone: String? = null
     var endTimeZone: String? = null
     var allDay: Boolean = false

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -28,8 +28,8 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
         let calendarId: String
         let title: String
         let description: String?
-        let start: Int64
-        let end: Int64
+        let eventStartDate: Int64
+        let eventEndDate: Int64
         let startTimeZone: String?
         let allDay: Bool
         let attendees: [Attendee]
@@ -352,8 +352,8 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin {
             calendarId: calendarId,
             title: ekEvent.title ?? "New Event",
             description: ekEvent.notes,
-            start: Int64(ekEvent.startDate.millisecondsSinceEpoch),
-            end: Int64(ekEvent.endDate.millisecondsSinceEpoch),
+            eventStartDate: Int64(ekEvent.startDate.millisecondsSinceEpoch),
+            eventEndDate: Int64(ekEvent.endDate.millisecondsSinceEpoch),
             startTimeZone: ekEvent.timeZone?.identifier,
             allDay: ekEvent.isAllDay,
             attendees: attendees,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar
 description: A cross platform plugin for modifying calendars on the user's device.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/builttoroam/device_calendar/tree/master
 
 dependencies:


### PR DESCRIPTION
Discovered in #374 by @nitinjavakid

Continuing #316 and originated from #297, we haven’t renamed all labels when migrating all the variables.

I’ve tested on Android but cannot get an iOS device to test yet. Can someone help test it?