### PR TITLE
more fixes to integration test

### DIFF
--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -3,11 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:uuid/uuid.dart';
 
-// import 'package:flutter_driver/driver_extension.dart';
 import 'package:device_calendar_example/main.dart' as app;
 
-/// NOTE: These integration tests are currently made to be run on a physical Android device where there is at least a calendar that can be written to.
-/// Calendar permissions are needed. See example/test_driver/integration_test.dart for how to run this
+/// NOTE: These integration tests are currently made to be run on a physical device where there is at least a calendar that can be written to.
+/// Calendar permissions are needed. See example/test_driver/integration_test.dart for how to run this on Android
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   group('Calendar plugin example', () {
@@ -81,7 +80,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(eventTitleFinder);
 
-      await tester.scrollUntilVisible(deleteButtonFinder, 5);
+      await tester.scrollUntilVisible(deleteButtonFinder, -5);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
       expect(eventTitleFinder, findsNothing);

--- a/example/integration_test/integration_test.dart
+++ b/example/integration_test/integration_test.dart
@@ -2,9 +2,12 @@ import 'dart:io';
 
 import 'package:integration_test/integration_test_driver.dart';
 
-// make sure 'adb devices' works on your local machine, then run the following:
+// make sure 'adb devices' works on your local machine, then from the root of the plugin, run the following:
 /* 
-flutter drive \ --driver=test_driver/integration_test.dart \ --target=integration_test/app_test.dart 
+1.
+cd example
+2.
+flutter drive --driver=integration_test/integration_test.dart --target=integration_test/app_test.dart 
   */
 
 Future<void> main() async {

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -38,10 +38,10 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   final RecurringEventDialog? _recurringEventDialog;
 
   TZDateTime? _startDate;
-  late TimeOfDay _startTime;
+  TimeOfDay? _startTime;
 
   TZDateTime? _endDate;
-  late TimeOfDay _endTime;
+  TimeOfDay? _endTime;
 
   AutovalidateMode _autovalidate = AutovalidateMode.disabled;
   DayOfWeekGroup? _dayOfWeekGroup = DayOfWeekGroup.None;

--- a/lib/src/device_calendar.dart
+++ b/lib/src/device_calendar.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:sprintf/sprintf.dart';
 import 'package:timezone/timezone.dart';
 

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -1,8 +1,5 @@
 import '../../device_calendar.dart';
-import '../common/calendar_enums.dart';
 import '../common/error_messages.dart';
-import 'attendee.dart';
-import 'recurrence_rule.dart';
 import 'package:timezone/timezone.dart';
 import 'package:collection/collection.dart';
 
@@ -72,7 +69,7 @@ class Event {
     description = json['eventDescription'];
 
     final int? startTimestamp = json['eventStartDate'];
-    final String? startLocationName = json['startTimeZone'];
+    final String? startLocationName = json['eventStartTimeZone'];
     var startTimeZone = timeZoneDatabase.locations[startLocationName];
     startTimeZone ??= local;
     start = startTimestamp != null
@@ -80,7 +77,7 @@ class Event {
         : TZDateTime.now(local);
 
     final int? endTimestamp = json['eventEndDate'];
-    final String? endLocationName = json['endTimeZone'];
+    final String? endLocationName = json['eventEndTimeZone'];
     var endLocation = timeZoneDatabase.locations[endLocationName];
     endLocation ??= local;
     end = endTimestamp != null


### PR DESCRIPTION
Clearer instruction to run integration test, and fixed test instructions so that the test is actually working.

Also fixed some minor items so the test passes.

iOS should require some other way to grant permission before running the integration test. Like [this](https://stackoverflow.com/questions/66514569/grant-ios-permissions-to-flutter-driver-for-integration-test).

I don't have an iOS device with me so I can't confirm. If it works we can write in our instructions.