### PR TITLE
 [Fix][Android] Fix the compile error caused by andoidx.appcompat when building apk in release mode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.8.8'
-    api 'androidx.appcompat:appcompat:1.4.0'
+    api 'androidx.appcompat:appcompat:1.3.1'
     implementation 'org.dmfs:lib-recur:0.11.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
 }


### PR DESCRIPTION
 [Fix][Android] Fix the andoidx.appcompat that is incompatibility caused compile error when building apk in release mode

1.error: 'AAPT: error: resource android:attr/lStar' not found when building apk in release mode
2.causes: androidx.appcompat incompatibility

Signed-off-by: zhuyangyang <yangyang.zhu@pplingo.com>