### PR TITLE
Fixes for better testing

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -31,7 +31,8 @@ jobs:
         run: |
           cd example
           flutter build appbundle
-  test-macos:
+          flutter build apk
+  test-ios:
     name: iOS build test
     runs-on: macos-latest
     steps:

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -39,6 +39,8 @@ android {
 
     buildTypes {
         release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.builttoroam.devicecalendar.** { *; }


### PR DESCRIPTION
Fixes problem found when solving #401  and #399 

1. Proguard for `example` app
2. Tests `flutter build apk` as well, because somehow it behaves quite differently to  `flutter build appbundle`. That's why we did not notice the problems.