### PR TITLE
Add EventStatus property to Event

### DIFF
--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -50,6 +50,7 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTIO
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_ID_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_RECURRING_RULE_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_START_TIMEZONE_INDEX
+import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_STATUS_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_TITLE_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.REMINDER_MINUTES_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.REMINDER_PROJECTION
@@ -106,6 +107,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         gsonBuilder.registerTypeAdapter(RecurrenceFrequency::class.java, RecurrenceFrequencySerializer())
         gsonBuilder.registerTypeAdapter(DayOfWeek::class.java, DayOfWeekSerializer())
         gsonBuilder.registerTypeAdapter(Availability::class.java, AvailabilitySerializer())
+        gsonBuilder.registerTypeAdapter(EventStatus::class.java, EventStatusSerializer())
         _gson = gsonBuilder.create()
     }
 
@@ -492,6 +494,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         values.put(Events.CALENDAR_ID, calendarId)
         values.put(Events.DURATION, duration)
         values.put(Events.AVAILABILITY, getAvailability(event.availability))
+        values.put(Events.STATUS, getEventStatus(event.eventStatus))
 
         if (event.recurrenceRule != null) {
             val recurrenceRuleParams = buildRecurrenceRuleParams(event.recurrenceRule!!)
@@ -516,6 +519,13 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         Availability.BUSY -> Events.AVAILABILITY_BUSY
         Availability.FREE -> Events.AVAILABILITY_FREE
         Availability.TENTATIVE -> Events.AVAILABILITY_TENTATIVE
+        else -> null
+    }
+
+    private fun getEventStatus(eventStatus: EventStatus?): Int? = when (eventStatus) {
+        EventStatus.CONFIRMED -> Events.STATUS_CONFIRMED
+        EventStatus.TENTATIVE -> Events.STATUS_TENTATIVE
+        EventStatus.CANCELED -> Events.STATUS_CANCELED
         else -> null
     }
 
@@ -726,6 +736,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         val startTimeZone = cursor.getString(EVENT_PROJECTION_START_TIMEZONE_INDEX)
         val endTimeZone = cursor.getString(EVENT_PROJECTION_END_TIMEZONE_INDEX)
         val availability = parseAvailability(cursor.getInt(EVENT_PROJECTION_AVAILABILITY_INDEX))
+        val eventStatus = parseEventStatus(cursor.getInt(EVENT_PROJECTION_STATUS_INDEX))
 
         val event = Event()
         event.eventTitle = title ?: "New Event"
@@ -741,6 +752,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         event.eventStartTimeZone = startTimeZone
         event.eventEndTimeZone = endTimeZone
         event.availability = availability
+        event.eventStatus = eventStatus
 
         return event
     }
@@ -980,6 +992,13 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
         Events.AVAILABILITY_BUSY -> Availability.BUSY
         Events.AVAILABILITY_FREE -> Availability.FREE
         Events.AVAILABILITY_TENTATIVE -> Availability.TENTATIVE
+        else -> null
+    }
+
+    private fun parseEventStatus(status: Int): EventStatus? = when(status) {
+        Events.STATUS_CONFIRMED -> EventStatus.CONFIRMED
+        Events.STATUS_CANCELED -> EventStatus.CANCELED
+        Events.STATUS_TENTATIVE -> EventStatus.TENTATIVE
         else -> null
     }
 }

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -73,6 +73,7 @@ class DeviceCalendarPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware {
     private val LOCAL_ACCOUNT_NAME_ARGUMENT = "localAccountName"
     private val EVENT_AVAILABILITY_ARGUMENT = "availability"
     private val ATTENDANCE_STATUS_ARGUMENT = "attendanceStatus"
+    private val EVENT_STATUS_ARGUMENT = "eventStatus"
 
     private lateinit var _calendarDelegate: CalendarDelegate
 
@@ -177,6 +178,7 @@ class DeviceCalendarPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware {
         event.eventLocation = call.argument<String>(EVENT_LOCATION_ARGUMENT)
         event.eventURL = call.argument<String>(EVENT_URL_ARGUMENT)
         event.availability = parseAvailability(call.argument<String>(EVENT_AVAILABILITY_ARGUMENT))
+        event.eventStatus = parseEventStatus(call.argument<String>(EVENT_STATUS_ARGUMENT))
 
         if (call.hasArgument(RECURRENCE_RULE_ARGUMENT) && call.argument<Map<String, Any>>(RECURRENCE_RULE_ARGUMENT) != null) {
             val recurrenceRule = parseRecurrenceRuleArgs(call)
@@ -256,4 +258,11 @@ class DeviceCalendarPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware {
             } else {
                 Availability.valueOf(value)
             }
+
+    private fun parseEventStatus(value: String?): EventStatus? =
+        if (value == null || value == Constants.EVENT_STATUS_NONE) {
+            null
+        } else {
+            EventStatus.valueOf(value)
+        }
 }

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/EventStatusSerializer.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/EventStatusSerializer.kt
@@ -1,0 +1,15 @@
+package com.builttoroam.devicecalendar
+
+import com.builttoroam.devicecalendar.models.EventStatus
+import com.google.gson.*
+import java.lang.reflect.Type
+
+class EventStatusSerializer: JsonSerializer<EventStatus> {
+    override fun serialize(src: EventStatus?, typeOfSrc: Type?, context: JsonSerializationContext?): JsonElement {
+        if(src != null) {
+            return JsonPrimitive(src.name)
+        }
+        return JsonObject()
+    }
+
+}

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/common/Constants.kt
@@ -49,6 +49,7 @@ class Constants {
         const val EVENT_PROJECTION_START_TIMEZONE_INDEX: Int = 11
         const val EVENT_PROJECTION_END_TIMEZONE_INDEX: Int = 12
         const val EVENT_PROJECTION_AVAILABILITY_INDEX: Int = 13
+        const val EVENT_PROJECTION_STATUS_INDEX: Int = 14
 
         val EVENT_PROJECTION: Array<String> = arrayOf(
                 CalendarContract.Instances.EVENT_ID,
@@ -64,7 +65,8 @@ class Constants {
                 CalendarContract.Events.CUSTOM_APP_URI,
                 CalendarContract.Events.EVENT_TIMEZONE,
                 CalendarContract.Events.EVENT_END_TIMEZONE,
-                CalendarContract.Events.AVAILABILITY
+                CalendarContract.Events.AVAILABILITY,
+                CalendarContract.Events.STATUS
         )
 
         const val EVENT_INSTANCE_DELETION_ID_INDEX: Int = 0
@@ -106,5 +108,7 @@ class Constants {
         )
 
         const val AVAILABILITY_UNAVAILABLE = "UNAVAILABLE"
+
+        const val EVENT_STATUS_NONE = "NONE"
     }
 }

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/models/Event.kt
@@ -18,4 +18,5 @@ class Event {
     var organizer: Attendee? = null
     var reminders: MutableList<Reminder> = mutableListOf()
     var availability: Availability? = null
+    var eventStatus: EventStatus? = null
 }

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/models/EventStatus.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/models/EventStatus.kt
@@ -1,0 +1,7 @@
+package com.builttoroam.devicecalendar.models
+
+enum class EventStatus {
+    CONFIRMED,
+    CANCELED,
+    TENTATIVE
+}

--- a/example/lib/presentation/event_item.dart
+++ b/example/lib/presentation/event_item.dart
@@ -209,6 +209,27 @@ class _EventItemState extends State<EventItem> {
                       ],
                     ),
                   ),
+                  SizedBox(
+                    height: 10.0,
+                  ),
+                  Align(
+                    alignment: Alignment.topLeft,
+                    child: Row(
+                      children: [
+                        Container(
+                          width: _eventFieldNameWidth,
+                          child: Text('Status'),
+                        ),
+                        Expanded(
+                          child: Text(
+                            widget._calendarEvent?.status?.enumToString ??
+                                '',
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        )
+                      ],
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -60,6 +60,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   WeekNumber? _weekOfMonth;
   DayOfWeek? _selectedDayOfWeek = DayOfWeek.Monday;
   Availability _availability = Availability.Busy;
+  EventStatus? _eventStatus;
 
   List<Attendee> _attendees = [];
   List<Reminder> _reminders = [];
@@ -103,6 +104,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       _monthOfYear = MonthOfYear.January;
       _weekOfMonth = WeekNumber.First;
       _availability = Availability.Busy;
+      _eventStatus = EventStatus.None;
     } else {
       _startDate = _event!.start!;
       _endDate = _event!.end!;
@@ -145,6 +147,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
       }
 
       _availability = _event!.availability;
+      _eventStatus = _event!.status;
     }
 
     _startTime = TimeOfDay(hour: _startDate!.hour, minute: _startDate!.minute);
@@ -262,6 +265,32 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                         }).toList(),
                       ),
                     ),
+                    if(Platform.isAndroid)
+                      ListTile(
+                        leading: Text(
+                          'Status',
+                          style: TextStyle(fontSize: 16),
+                        ),
+                        trailing: DropdownButton<EventStatus>(
+                          value: _eventStatus,
+                          onChanged: (EventStatus? newValue) {
+                            setState(() {
+                              if (newValue != null) {
+                                _eventStatus = newValue;
+                                _event?.status = newValue;
+                              }
+                            });
+                          },
+                          items: EventStatus.values
+                              .map<DropdownMenuItem<EventStatus>>(
+                                  (EventStatus value) {
+                            return DropdownMenuItem<EventStatus>(
+                              value: value,
+                              child: Text(value.enumToString),
+                            );
+                          }).toList(),
+                        ),
+                      ),
                     SwitchListTile(
                       value: _event?.allDay ?? false,
                       onChanged: (value) =>
@@ -899,6 +928,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
               _event?.attendees = _attendees;
               _event?.reminders = _reminders;
               _event?.availability = _availability;
+              _event?.status = _eventStatus;
               var createEventResult =
                   await _deviceCalendarPlugin.createOrUpdateEvent(_event);
               if (createEventResult?.isSuccess == true) {

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -41,6 +41,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
         let organizer: Attendee?
         let reminders: [Reminder]
         let availability: Availability?
+        let eventStatus: EventStatus?
     }
     
     struct RecurrenceRule: Codable {
@@ -71,6 +72,13 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
 		case FREE
 		case TENTATIVE
 		case UNAVAILABLE
+    }
+
+    enum EventStatus: String, Codable {
+        case CONFIRMED
+		case TENTATIVE
+		case CANCELED
+		case NONE
     }
     
     static let channelName = "plugins.builttoroam.com/device_calendar"
@@ -126,6 +134,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
     let calendarColorArgument = "calendarColor"
     let availabilityArgument = "availability"
     let attendanceStatusArgument = "attendanceStatus"
+    let eventStatusArgument = "eventStatus"
     let validFrequencyTypes = [EKRecurrenceFrequency.daily, EKRecurrenceFrequency.weekly, EKRecurrenceFrequency.monthly, EKRecurrenceFrequency.yearly]
     
     var flutterResult : FlutterResult?
@@ -375,7 +384,8 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
             recurrenceRule: recurrenceRule,
             organizer: convertEkParticipantToAttendee(ekParticipant: ekEvent.organizer),
             reminders: reminders,
-            availability: convertEkEventAvailability(ekEventAvailability: ekEvent.availability)
+            availability: convertEkEventAvailability(ekEventAvailability: ekEvent.availability),
+            eventStatus: convertEkEventStatus(ekEventStatus: ekEvent.status)
         )
 
         return event
@@ -407,6 +417,21 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
 			return Availability.TENTATIVE
 		case .unavailable:
 			return Availability.UNAVAILABLE
+        default:
+            return nil
+        }
+    }
+
+    private func convertEkEventStatus(ekEventStatus: EKEventStatus?) -> EventStatus? {
+        switch ekEventStatus {
+        case .confirmed:
+			return EventStatus.CONFIRMED
+        case .tentative:
+            return EventStatus.TENTATIVE
+		case .canceled:
+			return EventStatus.CANCELED
+		case .none?:
+			return EventStatus.NONE
         default:
             return nil
         }

--- a/lib/src/common/calendar_enums.dart
+++ b/lib/src/common/calendar_enums.dart
@@ -52,6 +52,13 @@ enum Availability {
   Unavailable,
 }
 
+enum EventStatus {
+  None,
+  Confirmed,
+  Canceled,
+  Tentative,
+}
+
 extension DayOfWeekExtension on DayOfWeek {
   static int _value(DayOfWeek val) {
     switch (val) {
@@ -278,6 +285,23 @@ extension AvailabilityExtensions on Availability {
         return 'TENTATIVE';
       case Availability.Unavailable:
         return 'UNAVAILABLE';
+    }
+  }
+
+  String get enumToString => _enumToString(this);
+}
+
+extension EventStatusExtensions on EventStatus {
+  String _enumToString(EventStatus enumValue) {
+    switch (enumValue) {
+      case EventStatus.Confirmed:
+        return 'CONFIRMED';
+      case EventStatus.Tentative:
+        return 'TENTATIVE';
+      case EventStatus.Canceled:
+        return 'CANCELED';
+      case EventStatus.None:
+        return 'NONE';
     }
   }
 

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -46,6 +46,9 @@ class Event {
   /// Indicates if this event counts as busy time, tentative, unavaiable or is still free time
   late Availability availability;
 
+  /// Indicates if this event is of confirmed, canceled, tentative or none status
+  EventStatus? status;
+  
   ///Note for development:
   ///
   ///JSON field names are coded in dart, swift and kotlin to facilitate data exchange.
@@ -68,7 +71,8 @@ class Event {
       this.availability = Availability.Busy,
       this.location,
       this.url,
-      this.allDay = false});
+      this.allDay = false,
+      this.status});
 
   ///Get Event from JSON.
   ///
@@ -138,6 +142,7 @@ class Event {
     }
     location = json['eventLocation'];
     availability = parseStringToAvailability(json['availability']);
+    status = parseStringToEventStatus(json['eventStatus']);
 
     foundUrl = json['eventURL']?.toString();
     if (foundUrl?.isEmpty ?? true) {
@@ -145,8 +150,6 @@ class Event {
     } else {
       url = Uri.dataFromString(foundUrl as String);
     }
-
-    availability = parseStringToAvailability(json['availability']);
 
     if (json['attendees'] != null) {
       attendees = json['attendees'].map<Attendee>((decodedAttendee) {
@@ -198,6 +201,7 @@ class Event {
     data['eventLocation'] = location;
     data['eventURL'] = url?.data?.contentText;
     data['availability'] = availability.enumToString;
+    data['eventStatus'] = status?.enumToString;
 
     if (attendees != null) {
       data['attendees'] = attendees?.map((a) => a?.toJson()).toList();
@@ -232,6 +236,20 @@ class Event {
         return Availability.Unavailable;
     }
     return Availability.Busy;
+  }
+
+  EventStatus? parseStringToEventStatus(String? value) {
+    var testValue = value?.toUpperCase();
+    switch (testValue) {
+      case 'CONFIRMED':
+        return EventStatus.Confirmed;
+      case 'TENTATIVE':
+        return EventStatus.Tentative;
+      case 'CANCELED':
+        return EventStatus.Canceled;
+      case 'NONE':
+        return EventStatus.None;
+    }
   }
 
   bool updateStartLocation(String? newStartLocation) {

--- a/test/device_calendar_test.dart
+++ b/test/device_calendar_test.dart
@@ -211,7 +211,8 @@ void main() {
         description: 'Test description',
         recurrenceRule: recurrence,
         reminders: [reminder],
-        availability: Availability.Busy);
+        availability: Availability.Busy,
+        status: EventStatus.Confirmed);
 
     final stringEvent = event.toJson();
     expect(stringEvent, isNotNull);
@@ -235,5 +236,6 @@ void main() {
     expect(newEvent.reminders, isNotNull);
     expect(newEvent.reminders?.length, equals(1));
     expect(newEvent.availability, equals(event.availability));
+    expect(newEvent.status, equals(event.status));
   });
 }


### PR DESCRIPTION
Android: https://developer.android.com/reference/android/provider/CalendarContract.EventsColumns#STATUS
iOS: https://developer.apple.com/documentation/eventkit/ekevent/1507158-status

This property is useful when the organizer provides a confirmation of the meeting to the attendees. There is more information about it in this [link](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.11)

In iOS it seems to be read only. That's the reason I add a platform verification in example, allowing EventStatus edition only in Android. But I am not sure if there is a way to edit the status property in iOS side.

I tested it in both platforms