### PR TITLE
Fixed bug where DAILY freq gave a compile error

### DIFF
--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -788,7 +788,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 }?.toMutableList()
             }
             
-            else -> throw IllegalStateException("Someone forgot to add enough fragment cases to 'when' clause!")
+            else -> throw IllegalStateException("Only Freq WEEKLY, MONTHLY or YEARLY acceptable as a rfcRecurrenceRule!")
         }
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -787,6 +787,8 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                     DayOfWeek.values().find { dayOfWeek -> dayOfWeek.ordinal == it.weekday.ordinal }
                 }?.toMutableList()
             }
+            
+            else -> throw IllegalStateException("Someone forgot to add enough fragment cases to 'when' clause!")
         }
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -788,7 +788,11 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                 }?.toMutableList()
             }
             
-            else -> throw IllegalStateException("Only Freq WEEKLY, MONTHLY or YEARLY acceptable as a rfcRecurrenceRule!")
+            Freq.DAILY -> {
+                recurrenceRule.daysOfWeek = DayOfWeek.values().toMutableList()
+            }
+
+            else -> throw IllegalStateException("The recurrence rule frequency ${rfcRecurrenceRule.freq}  is not supported")
         }
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()


### PR DESCRIPTION
The `when` branch was not exhaustive enough resulting in build errors when building for Android
```
e: C:\flutter\.pub-cache\hosted\pub.dartlang.org\device_calendar-4.2.0\android\src\main\kotlin\com\builttoroam\devicecalendar\CalendarDelegate.kt: (772, 9): 'when' expression must be exhaustive, add necessary 'DAILY', 'HOURLY', 'MINUTELY', 'SECONDLY' branches or 'else' branch instead

FAILURE: Build failed with an exception.
```

I have added an `else` condition throwing an exception to combat this issue:
```kotlin
else -> throw IllegalStateException("Only Freq WEEKLY, MONTHLY or YEARLY acceptable as a rfcRecurrenceRule!")
```