### PR TITLE
Updated multiple underlying dependencies (closes #437).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- To benefit from the current changelog reader in CI/CD, please follow the changelog format from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). -->
 
+## [4.2.1](https://github.com/builttoroam/device_calendar/releases/tag/4.2.1)
+
+- Updated multiple underlying dependencies
+  - *Note:* `timezone 0.9.0` [removed named database files](https://pub.dev/packages/timezone/changelog#090). If you are only using `device_calendar`, you can ignore this note.
+
 ## [4.2.0](https://github.com/builttoroam/device_calendar/releases/tag/4.2.0)
 
 - Fix: apks can be build correctly now

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,20 @@
 name: device_calendar
 description: A cross platform plugin for modifying calendars on the user's device.
-version: 4.2.0
+version: 4.2.1
 homepage: https://github.com/builttoroam/device_calendar/tree/master
 
 dependencies:
   flutter:
     sdk: flutter
-  collection: ^1.15.0
-  sprintf: ^6.0.0
-  timezone: ^0.8.0
+  collection: ^1.16.0
+  sprintf: ^6.0.2
+  timezone: ^0.9.0
   flutter_native_timezone: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
- bumped version to `4.2.1` and populated changelog
- updated `timezone` to [`0.9.0`](https://pub.dev/packages/timezone/changelog#090) (for details see #437)
- updated `collection` to [`1.16.0`](https://pub.dev/packages/collection/changelog#1160) (no breaking changes)
- updated `sprintf` to [`6.0.2`](https://pub.dev/packages/sprintf/changelog) (no breaking changes)
- updated `flutter_lints` to [`2.0.1`](https://pub.dev/packages/flutter_lints/changelog#201) (no breaking changes)