### PR TITLE
packages cleanup

### DIFF
--- a/example/lib/presentation/event_item.dart
+++ b/example/lib/presentation/event_item.dart
@@ -4,7 +4,6 @@ import 'package:device_calendar/device_calendar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:intl/intl.dart';
-import 'package:timezone/timezone.dart';
 
 import 'recurring_event_dialog.dart';
 

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:intl/intl.dart';
-import 'package:timezone/timezone.dart';
 
 import '../date_time_picker.dart';
 import '../recurring_event_dialog.dart';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   intl: ^0.17.0
   uuid: ^3.0.6
-  timezone: ^0.9.0
   flutter_native_timezone: ^2.0.0
   device_calendar:
     path: ../

--- a/lib/device_calendar.dart
+++ b/lib/device_calendar.dart
@@ -14,3 +14,4 @@ export 'src/models/platform_specifics/ios/attendance_status.dart';
 export 'src/models/platform_specifics/android/attendee_details.dart';
 export 'src/models/platform_specifics/android/attendance_status.dart';
 export 'src/device_calendar.dart';
+export 'package:timezone/timezone.dart';

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:collection/collection.dart';
-import 'package:timezone/timezone.dart';
 
 import '../../device_calendar.dart';
 import '../common/error_messages.dart';
@@ -83,7 +82,6 @@ class Event {
     if (json == null) {
       throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
-
     String? foundUrl;
     String? startLocationName;
     String? endLocationName;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.16.0
-  sprintf: ^6.0.2
   timezone: ^0.9.0
-  flutter_native_timezone: ^2.0.0
-  intl: ^0.17.0
   rrule: ^0.2.7
 
 dev_dependencies:


### PR DESCRIPTION
No more hacky `timezone` imports needed, now that the files are (correctly) exported.

Also removed packages that ain't essential, slimming it down