### PR TITLE
Fixed All day events start time may be incorrect (iOS only) #337

### DIFF
--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -815,12 +815,12 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
             ekEvent!.notes = description
             ekEvent!.isAllDay = isAllDay
             ekEvent!.startDate = startDate
-			ekEvent!.endDate = endDate
+            ekEvent!.endDate = endDate
             
 			if (!isAllDay) { 
-				let timeZone = TimeZone(identifier: startTimeZoneString ?? TimeZone.current.identifier) ?? .current
+                let timeZone = TimeZone(identifier: startTimeZoneString ?? TimeZone.current.identifier) ?? .current
                 ekEvent!.timeZone = timeZone
-			}
+            }
             
             ekEvent!.calendar = ekCalendar!
             ekEvent!.location = location

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -815,13 +815,13 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
             ekEvent!.notes = description
             ekEvent!.isAllDay = isAllDay
             ekEvent!.startDate = startDate
-            if (isAllDay) { ekEvent!.endDate = startDate }
-            else {
-                ekEvent!.endDate = endDate
-
-                let timeZone = TimeZone(identifier: startTimeZoneString ?? TimeZone.current.identifier) ?? .current
+			ekEvent!.endDate = endDate
+            
+			if (!isAllDay) { 
+				let timeZone = TimeZone(identifier: startTimeZoneString ?? TimeZone.current.identifier) ?? .current
                 ekEvent!.timeZone = timeZone
-            }
+			}
+            
             ekEvent!.calendar = ekCalendar!
             ekEvent!.location = location
 

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -440,13 +440,13 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
     private func convertEkEventStatus(ekEventStatus: EKEventStatus?) -> EventStatus? {
         switch ekEventStatus {
         case .confirmed:
-			return EventStatus.CONFIRMED
+            return EventStatus.CONFIRMED
         case .tentative:
             return EventStatus.TENTATIVE
-		case .canceled:
-			return EventStatus.CANCELED
-		case .none?:
-			return EventStatus.NONE
+        case .canceled:
+            return EventStatus.CANCELED
+        case .none?:
+            return EventStatus.NONE
         default:
             return nil
         }
@@ -817,7 +817,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
             ekEvent!.startDate = startDate
             ekEvent!.endDate = endDate
             
-			if (!isAllDay) { 
+            if (!isAllDay) { 
                 let timeZone = TimeZone(identifier: startTimeZoneString ?? TimeZone.current.identifier) ?? .current
                 ekEvent!.timeZone = timeZone
             }


### PR DESCRIPTION
Fixed fullDay with DateRange events creation (not only one fullday events possible to create) Timezone should be set only if event is not full day