### PR TITLE
iOS: Fix error when adding attendees due to UUID is nil.

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   device_calendar: 9cb33f88a02e19652ec7b8b122ca778f751b1f7b
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_timezone: 5f05b2de06c9776b4cc70e1839f03de178394d22
-  integration_test: 7db6d89f336f671dcbc7563ee27a5b08f6f8aee1
+  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
 
 PODFILE CHECKSUM: d3740c426905916d1f2ada0ddfce28cc99f7b7af
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -407,7 +407,10 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                         itemBuilder: (context, index) {
                           return Container(
                             color: (_attendees?[index].isOrganiser ?? false)
-                                ? Colors.greenAccent[100]
+                                ? MediaQuery.of(context).platformBrightness ==
+                                Brightness.dark
+                                ? Colors.black26
+                                : Colors.greenAccent[100]
                                 : Colors.transparent,
                             child: ListTile(
                               onTap: () async {

--- a/example/lib/presentation/pages/event_attendee.dart
+++ b/example/lib/presentation/pages/event_attendee.dart
@@ -64,7 +64,7 @@ class _EventAttendeePageState extends State<EventAttendeePage> {
                   child: TextFormField(
                     controller: _nameController,
                     validator: (value) {
-                      if (_attendee!.isCurrentUser == false &&
+                      if (_attendee?.isCurrentUser == false &&
                           (value == null || value.isEmpty)) {
                         return 'Please enter a name';
                       }
@@ -153,9 +153,9 @@ class _EventAttendeePageState extends State<EventAttendeePage> {
                       name: _nameController.text,
                       emailAddress: _emailAddressController.text,
                       role: _role,
-                      isOrganiser: _attendee!.isOrganiser,
-                      isCurrentUser: _attendee!.isCurrentUser,
-                      iosAttendeeDetails: _attendee!.iosAttendeeDetails,
+                      isOrganiser: _attendee?.isOrganiser ?? false,
+                      isCurrentUser: _attendee?.isCurrentUser ?? false,
+                      iosAttendeeDetails: _attendee?.iosAttendeeDetails,
                       androidAttendeeDetails: AndroidAttendeeDetails.fromJson(
                           {'attendanceStatus': _status.index}));
 

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -856,6 +856,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
         let ekAttendeeClass: AnyClass? = NSClassFromString("EKAttendee")
         if let type = ekAttendeeClass as? NSObject.Type {
             let participant = type.init()
+            participant.setValue(UUID().uuidString, forKey: "UUID")
             participant.setValue(name, forKey: "displayName")
             participant.setValue(emailAddress, forKey: "emailAddress")
             participant.setValue(role, forKey: "participantRole")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
     sdk: flutter
   collection: ^1.16.0
   timezone: ^0.9.0
-  rrule: ^0.2.7
+  rrule: ^0.2.10
 
 dev_dependencies:
   flutter_test:

--- a/test/device_calendar_test.dart
+++ b/test/device_calendar_test.dart
@@ -2,7 +2,6 @@ import 'package:device_calendar/device_calendar.dart';
 import 'package:device_calendar/src/common/error_codes.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:timezone/timezone.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
I recently had several crashes on my app (iOS users) and found out that the adding attendee functionality was broken.

#### Error:
```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSDictionaryM setObject:forKeyedSubscript:]: key cannot be nil'
```

I was able to locate the error in the _SwiftDeviceCalendarPlugin.swift_ file (line 692):

```swift
ekEvent!.setValue(attendees, forKey: "attendees")
```

And adding the line below to the createParticipant in the same file solved the problem.
*Thanks to this [solution](https://stackoverflow.com/a/74265315/13558952).*
```swift
participant.setValue(UUID().uuidString, forKey: "UUID")
```

Besides that I

- had to change some null errors in the example app (/event_attendee.dart),
- changed a color value for dark mode in (/calendar_event.dart) as the greenAccent[100] looks awful in dark mode. ;-),
- updated rrule package dependency from 0.2.7 to 0.2.10,
- deleted unneccessary dependency in _test/device_calendar_test.dart_