### PR TITLE
Removed platform-specific logic from the example app.

### DIFF
--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -332,41 +332,38 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                             },
                           ),
                         ),
-                      // Only add the 'To' Date for non-allDay events on all
-                      // platforms except Android (which allows multiple-day allDay events)
-                      if (_event?.allDay == false || Platform.isAndroid)
-                        Padding(
-                          padding: const EdgeInsets.all(10.0),
-                          child: DateTimePicker(
-                            labelText: 'To',
-                            selectedDate: _endDate,
-                            selectedTime: _endTime,
-                            enableTime: _event?.allDay == false,
-                            selectDate: (DateTime date) {
-                              setState(
-                                () {
-                                  var currentLocation =
-                                      timeZoneDatabase.locations[_timezone];
-                                  if (currentLocation != null) {
-                                    _endDate =
-                                        TZDateTime.from(date, currentLocation);
-                                    _event?.end = _combineDateWithTime(
-                                        _endDate, _endTime);
-                                  }
-                                },
-                              );
-                            },
-                            selectTime: (TimeOfDay time) {
-                              setState(
-                                () {
-                                  _endTime = time;
-                                  _event?.end =
-                                      _combineDateWithTime(_endDate, _endTime);
-                                },
-                              );
-                            },
-                          ),
+                      Padding(
+                        padding: const EdgeInsets.all(10.0),
+                        child: DateTimePicker(
+                          labelText: 'To',
+                          selectedDate: _endDate,
+                          selectedTime: _endTime,
+                          enableTime: _event?.allDay == false,
+                          selectDate: (DateTime date) {
+                            setState(
+                              () {
+                                var currentLocation =
+                                    timeZoneDatabase.locations[_timezone];
+                                if (currentLocation != null) {
+                                  _endDate =
+                                      TZDateTime.from(date, currentLocation);
+                                  _event?.end = _combineDateWithTime(
+                                      _endDate, _endTime);
+                                }
+                              },
+                            );
+                          },
+                          selectTime: (TimeOfDay time) {
+                            setState(
+                              () {
+                                _endTime = time;
+                                _event?.end =
+                                    _combineDateWithTime(_endDate, _endTime);
+                              },
+                            );
+                          },
                         ),
+                      ),
                       if (_event?.allDay == false && Platform.isAndroid)
                         Padding(
                           padding: const EdgeInsets.all(10.0),


### PR DESCRIPTION
Now that we have multi-day all-day events on both platforms (see https://github.com/builttoroam/device_calendar/pull/450), handling the platforms differently is no longer necessary.

This PR includes changes to the example app. Splitting it up results in https://github.com/builttoroam/device_calendar/pull/450 no longer being blocked.