### PR TITLE
Fix enum switch for Kotlin 1.7.10

### DIFF
--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -775,6 +775,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                     DayOfWeek.values().find { dayOfWeek -> dayOfWeek.ordinal == it.weekday.ordinal }
                 }?.toMutableList()
             }
+            else -> null
         }
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()


### PR DESCRIPTION
**Describe the bug**



```
Compilation issue with Kotlin 1.7.10.
/builds/projet-root/.pub-cache/hosted/pub.dartlang.org/device_calendar-4.2.0/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt: (772, 9): 'when' expression must be exhaustive, add necessary 'DAILY', 'HOURLY', 'MINUTELY', 'SECONDLY' branches or 'else' branch instead
[282](https://gitlab.socrate.vsct.fr/projet-root/-/jobs/14970613#L282)FAILURE: Build failed with an exception.
```



**Actual code**



        when (rfcRecurrenceRule.freq) {
            Freq.WEEKLY, Freq.MONTHLY, Freq.YEARLY -> {
                recurrenceRule.daysOfWeek = rfcRecurrenceRule.byDayPart?.mapNotNull {
                    DayOfWeek.values().find { dayOfWeek -> dayOfWeek.ordinal == it.weekday.ordinal }
                }?.toMutableList()
            }
        }



**Proposed correction code**



        when (rfcRecurrenceRule.freq) {
            Freq.WEEKLY, Freq.MONTHLY, Freq.YEARLY -> {
                recurrenceRule.daysOfWeek = rfcRecurrenceRule.byDayPart?.mapNotNull {
                    DayOfWeek.values().find { dayOfWeek -> dayOfWeek.ordinal == it.weekday.ordinal }
                }?.toMutableList()
            }
            else -> null
        }


Let me know if you need more information.

Regards