### PR TITLE
Remove faulty requestPermissions implementation in favor of working one

### DIFF
--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -1024,7 +1024,7 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
         self.finishWithUnauthorizedError(result: result)
     }
 
-    private func requestPermissions(completion: @escaping (Bool) -> Void) {
+    private func requestPermissions(_ completion: @escaping (Bool) -> Void) {
         if hasEventPermissions() {
             completion(true)
             return
@@ -1038,16 +1038,6 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
     private func hasEventPermissions() -> Bool {
         let status = EKEventStore.authorizationStatus(for: .event)
         return status == EKAuthorizationStatus.authorized
-    }
-
-    private func requestPermissions(_ result: @escaping FlutterResult) {
-        if hasEventPermissions()  {
-            result(true)
-        }
-        eventStore.requestAccess(to: .event, completion: {
-            (accessGranted: Bool, _: Error?) in
-            result(accessGranted)
-        })
     }
 }
 


### PR DESCRIPTION
Tthe current Swift-implentation of `requestPermissions` does not return if permissions have already been granted. Thus, if it is called more than once, subsequent attempts try to request permissions again, causing the call to fail with a 400-error (`To create or update an all day event you must provide calendar ID, event with a title and event's start date`).

There was already a second implementation of `requestPermissions` which wasn't used anywhere but correctly short-circuits if permissions have already been granted so I thought it would be better to use that.

EDIT: Actually, the errors seem to be caused by an error on my end. Regardless, this change seems reasonable to me, if less urgent :)