### PR TITLE
Added 'else' in compliance with Kotlin 1.7.21.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- To benefit from the current changelog reader in CI/CD, please follow the changelog format from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). -->
 
+## [4.3.1](https://github.com/builttoroam/device_calendar/releases/tag/4.3.1)
+
+- Fixed an [issue](https://github.com/builttoroam/device_calendar/issues/470) that prevented the plugin from being used with Kotlin 1.7.10
+
 ## [4.3.0](https://github.com/builttoroam/device_calendar/releases/tag/4.3.0)
 
 - Updated multiple underlying dependencies

--- a/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -787,6 +787,7 @@ class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener {
                     DayOfWeek.values().find { dayOfWeek -> dayOfWeek.ordinal == it.weekday.ordinal }
                 }?.toMutableList()
             }
+            else -> recurrenceRule.daysOfWeek = null
         }
 
         val rfcRecurrenceRuleString = rfcRecurrenceRule.toString()

--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -416,7 +416,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                         itemCount: _attendees.length,
                         itemBuilder: (context, index) {
                           return Container(
-                            color: (_attendees?[index].isOrganiser ?? false)
+                            color: (_attendees[index].isOrganiser)
                                 ? MediaQuery.of(context).platformBrightness ==
                                         Brightness.dark
                                     ? Colors.black26

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -250,6 +250,7 @@ class Event {
       case 'NONE':
         return EventStatus.None;
     }
+    return null;
   }
 
   bool updateStartLocation(String? newStartLocation) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar
 description: A cross platform plugin for modifying calendars on the user's device.
-version: 4.3.0
+version: 4.3.1
 homepage: https://github.com/builttoroam/device_calendar/tree/master
 
 dependencies:


### PR DESCRIPTION
Issue #470 

Error

`CalendarDelegate.kt:784:9 'when' expression must be exhaustive, add necessary 'DAILY', 'HOURLY', 'MINUTELY', 'SECONDLY' branches or 'else' branch instead`

Fix

`when (rfcRecurrenceRule.freq) {
            Freq.WEEKLY, Freq.MONTHLY, Freq.YEARLY -> {
                recurrenceRule.daysOfWeek = rfcRecurrenceRule.byDayPart?.mapNotNull {
                    DayOfWeek.values().find { dayOfWeek -> dayOfWeek.ordinal == it.weekday.ordinal }
                }?.toMutableList()
            }
            else -> recurrenceRule.daysOfWeek = null
}`

Added 'else' so that it is compliant with Kotlin 1.7.21. 