### PR TITLE
Fix retrieving events for more than 4 years range

### DIFF
--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -329,10 +329,6 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
                         // Adding 4 years to the start date
                         var currentEndDate = startDate.addingTimeInterval(fourYearsTimeInterval)
                         while currentEndDate <= endDate {
-                            // debugPrint("Start date of current range: \(currentStartDate)")
-                            // debugPrint("End date of current range: \(currentEndDate.addingTimeInterval(-1))")
-                            // debugPrint("Range size: \(roundedRangeSize / (365 * 24 * 60 * 60)) years\n")
-                            
                             let predicate = self.eventStore.predicateForEvents(
                                 withStart: currentStartDate,
                                 end: currentEndDate.addingTimeInterval(-1),
@@ -347,12 +343,6 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
                         
                         // If the cycle doesn't end exactly on the end date
                         if currentStartDate <= endDate {
-                            let finalRangeSize = endDate.timeIntervalSince(currentStartDate)
-                            
-                            // debugPrint("Start date of final range: \(currentStartDate)")
-                            // debugPrint("End date of final range: \(endDate)")
-                            // debugPrint("Range size: \(finalRangeSize / (365 * 24 * 60 * 60)) years\n")
-                            
                             let predicate = self.eventStore.predicateForEvents(
                                 withStart: currentStartDate,
                                 end: endDate,

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -324,13 +324,11 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
                     if ekCalendar != nil {
                         var ekEvents = [EKEvent]()
                         let fourYearsInSeconds = 4 * 365 * 24 * 60 * 60
+                        let fourYearsTimeInterval = TimeInterval(fourYearsInSeconds)
                         var currentStartDate = startDate
                         // Adding 4 years to the start date
-                        var currentEndDate = startDate.addingTimeInterval(TimeInterval(fourYearsInSeconds))
+                        var currentEndDate = startDate.addingTimeInterval(fourYearsTimeInterval)
                         while currentEndDate <= endDate {
-                            let rangeSize = currentEndDate.timeIntervalSince(currentStartDate)
-                            let roundedRangeSize = Int(rangeSize / Double(fourYearsInSeconds)) * fourYearsInSeconds
-                            
                             // debugPrint("Start date of current range: \(currentStartDate)")
                             // debugPrint("End date of current range: \(currentEndDate.addingTimeInterval(-1))")
                             // debugPrint("Range size: \(roundedRangeSize / (365 * 24 * 60 * 60)) years\n")
@@ -342,9 +340,9 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
                             let batch = self.eventStore.events(matching: predicate)
                             ekEvents.append(contentsOf: batch)
                             
-                            // Move the start and end dates forward by the rounded range size
+                            // Move the start and end dates forward by the [fourYearsTimeInterval]
                             currentStartDate = currentEndDate
-                            currentEndDate = currentStartDate.addingTimeInterval(TimeInterval(roundedRangeSize))
+                            currentEndDate = currentStartDate.addingTimeInterval(fourYearsTimeInterval)
                         }
                         
                         // If the cycle doesn't end exactly on the end date


### PR DESCRIPTION
Fix for https://github.com/builttoroam/device_calendar/issues/452

The current implementation of receiving events on iOS does not take into account that `EKEventStore` returns events for a maximum of 4 years ([doc](https://developer.apple.com/documentation/eventkit/ekeventstore/1507479-predicateforevents#discussion)). Accordingly, when specifying a range of more than 4 years, not all events are received.