### PR TITLE
Request FullAccess on iOS17+

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -34,8 +34,11 @@ jobs:
           flutter build apk
   test-ios:
     name: iOS build test
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0-beta'
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:

--- a/README.md
+++ b/README.md
@@ -107,4 +107,11 @@ For iOS 10+ support, you'll need to modify the `Info.plist` to add the following
 <string>Access contacts for event attendee editing.</string>
 ```
 
+For iOS 17+ support, add the following key/value pair as well.
+
+```xml
+<key>NSCalendarsFullAccessUsageDescription</key>
+<string>Access most functions for calendar viewing and editing.</string>
+```
+
 Note that on iOS, this is a Swift plugin. There is a known issue being tracked [here](https://github.com/flutter/flutter/issues/16049) by the Flutter team, where adding a plugin developed in Swift to an Objective-C project causes problems. If you run into such issues, please look at the suggested workarounds there.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,13 +25,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.builttoroam.devicecalendarexample"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"

--- a/ios/Classes/SwiftDeviceCalendarPlugin.swift
+++ b/ios/Classes/SwiftDeviceCalendarPlugin.swift
@@ -1029,15 +1029,26 @@ public class SwiftDeviceCalendarPlugin: NSObject, FlutterPlugin, EKEventViewDele
             completion(true)
             return
         }
-        eventStore.requestAccess(to: .event, completion: {
-            (accessGranted: Bool, _: Error?) in
-            completion(accessGranted)
-        })
+        if #available(iOS 17, *) {
+            eventStore.requestFullAccessToEvents {
+                (accessGranted: Bool, _: Error?) in
+                completion(accessGranted)
+            }
+        } else {
+            eventStore.requestAccess(to: .event, completion: {
+                (accessGranted: Bool, _: Error?) in
+                completion(accessGranted)
+            })
+        }
     }
 
     private func hasEventPermissions() -> Bool {
         let status = EKEventStore.authorizationStatus(for: .event)
-        return status == EKAuthorizationStatus.authorized
+        if #available(iOS 17, *) {
+            return status == EKAuthorizationStatus.fullAccess
+        } else {
+            return status == EKAuthorizationStatus.authorized
+        }
     }
 }
 


### PR DESCRIPTION
Issue #490 

A distinction between write-only access and full access has been made since iOS17.
https://developer.apple.com/documentation/technotes/tn3152-migrating-to-the-latest-calendar-access-levels

This PR obtains full access, but it may be inappropriate if you intend to be able to handle write-only access separately.


