### PR TITLE
Fix: Update Set<T> to List<T> in calendar_event.dart to comply with rrule 0.2.16

### DIFF
--- a/example/lib/presentation/pages/calendar_event.dart
+++ b/example/lib/presentation/pages/calendar_event.dart
@@ -674,11 +674,11 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                               setState(() {
                                 if (value) {
                                   _rrule = _rrule?.copyWith(
-                                      byMonthDays: {1}, byWeekDays: {});
+                                      byMonthDays: [1], byWeekDays: []);
                                 } else {
                                   _rrule = _rrule?.copyWith(
-                                      byMonthDays: {},
-                                      byWeekDays: {ByWeekDayEntry(1, 1)});
+                                      byMonthDays: [],
+                                      byWeekDays: [ByWeekDayEntry(1, 1)]);
                                 }
                               });
                             },
@@ -694,7 +694,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                 if (value != null) {
                                   setState(() {
                                     _rrule = _rrule
-                                        ?.copyWith(byMonths: {value.index + 1});
+                                        ?.copyWith(byMonths: [value.index + 1]);
                                     _getValidDaysOfMonth(_rrule?.frequency);
                                   });
                                 }
@@ -722,7 +722,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                 if (value != null) {
                                   setState(() {
                                     _rrule =
-                                        _rrule?.copyWith(byMonthDays: {value});
+                                        _rrule?.copyWith(byMonthDays: [value]);
                                   });
                                 }
                               },
@@ -766,10 +766,10 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                             _rrule?.byWeekDays.first.day ?? 1;
                                         setState(() {
                                           _rrule = _rrule?.copyWith(
-                                              byWeekDays: {
+                                              byWeekDays: [
                                                 ByWeekDayEntry(
                                                     weekDay, value.index + 1)
-                                              });
+                                              ]);
                                         });
                                       }
                                     },
@@ -795,10 +795,10 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                             1;
                                         setState(() {
                                           _rrule = _rrule?.copyWith(
-                                              byWeekDays: {
+                                              byWeekDays: [
                                                 ByWeekDayEntry(
                                                     value.index + 1, weekNo)
-                                              });
+                                              ]);
                                         });
                                       }
                                     },
@@ -825,7 +825,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
                                         if (value != null) {
                                           setState(() {
                                             _rrule = _rrule?.copyWith(
-                                                byMonths: {value.index + 1});
+                                                byMonths: [value.index + 1]);
                                           });
                                         }
                                       },
@@ -1068,22 +1068,22 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
   void _updateDaysOfWeek() {
     switch (_dayOfWeekGroup) {
       case DayOfWeekGroup.Weekday:
-        _rrule = _rrule?.copyWith(byWeekDays: {
+        _rrule = _rrule?.copyWith(byWeekDays: [
           ByWeekDayEntry(1),
           ByWeekDayEntry(2),
           ByWeekDayEntry(3),
           ByWeekDayEntry(4),
           ByWeekDayEntry(5),
-        });
+        ]);
         break;
       case DayOfWeekGroup.Weekend:
-        _rrule = _rrule?.copyWith(byWeekDays: {
+        _rrule = _rrule?.copyWith(byWeekDays: [
           ByWeekDayEntry(6),
           ByWeekDayEntry(7),
-        });
+        ]);
         break;
       case DayOfWeekGroup.AllDays:
-        _rrule = _rrule?.copyWith(byWeekDays: {
+        _rrule = _rrule?.copyWith(byWeekDays: [
           ByWeekDayEntry(1),
           ByWeekDayEntry(2),
           ByWeekDayEntry(3),
@@ -1091,7 +1091,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
           ByWeekDayEntry(5),
           ByWeekDayEntry(6),
           ByWeekDayEntry(7),
-        });
+        ]);
         break;
       case DayOfWeekGroup.None:
       default:
@@ -1138,7 +1138,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
     }
   }
 
-  int _weekNumFromWeekDayOccurence(Set<ByWeekDayEntry> weekdays) {
+  int _weekNumFromWeekDayOccurence(List<ByWeekDayEntry> weekdays) {
     final weekNum = weekdays.first.occurrence;
     if (weekNum != null) {
       return weekNum - 1;
@@ -1168,7 +1168,7 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         }
         if (!hasByWeekDays && !hasByMonthDays) {
           _rrule = rrule
-              .copyWith(frequency: freq, byWeekDays: {ByWeekDayEntry(1, 1)});
+              .copyWith(frequency: freq, byWeekDays: [ByWeekDayEntry(1, 1)]);
         } else {
           _rrule = rrule.copyWith(frequency: freq);
         }
@@ -1177,8 +1177,8 @@ class _CalendarEventPageState extends State<CalendarEventPage> {
         if (!hasByWeekDays || !hasByMonths) {
           _rrule = rrule.copyWith(
               frequency: freq,
-              byWeekDays: {ByWeekDayEntry(1, 1)},
-              byMonths: {1});
+              byWeekDays: [ByWeekDayEntry(1, 1)],
+              byMonths: [1]);
         } else {
           _rrule = rrule.copyWith(frequency: freq);
         }


### PR DESCRIPTION
This PR addresses the type declaration change in the `rrule` library version 0.2.16. The library now uses `List<T>` instead of `Set<T>`, which necessitates the same change in `calendar_event.dart` of the `builttoroam/device_calendar` package.

Changes made:

- All instances of `Set<T>` in `calendar_event.dart` have been updated to `List<T>`.
- Necessary adjustments in methods/functions that were using `Set<T>` are made to handle `List<T>`.

This change ensures compatibility with the `rrule` library version 0.2.16 and prevents possible type errors. It is recommended to merge this PR to maintain the integrity and functionality of the `builttoroam/device_calendar` package.

Please review and let me know if any changes are required.
