### PR TITLE
Fix iOS workflow.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0-beta'
+          xcode-version: '15.0.1'
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
XCode version 15.0-beta is no longer available and causes all tests to break. Use version 15.0.1 instead.

This is a blocker for #531.