### PR TITLE
Added Privacy Manifests for iOS

### DIFF
--- a/ios/Resources/PrivacyInfo.xcprivacy
+++ b/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/ios/device_calendar.podspec
+++ b/ios/device_calendar.podspec
@@ -4,13 +4,13 @@
 Pod::Spec.new do |s|
   s.name             = 'device_calendar'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Cross Platform plugin to modify calendars'
   s.description      = <<-DESC
-A new flutter plugin project.
+  A cross platform plugin for modifying calendars on the user's device
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://github.com/builttoroam/device_calendar'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Built to Roam' => 'info@builttoroam.com' }
   s.source           = { :path => '.' }
   s.swift_version = '5.0'
   s.source_files = 'Classes/**/*'
@@ -18,5 +18,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   
   s.ios.deployment_target = '8.0'
+  s.resource_bundles = {'device_calendar' => ['Resources/PrivacyInfo.xcprivacy']}
 end
 


### PR DESCRIPTION
# What's Changed
Added a Privacy Manifest in preparation for May 1st's deadline for 3rd Party Libraries to include it.
Also added some detail to the Podspec but I don't mind removing it

# Rationale
> Starting May 1: You’ll need to include approved reasons for the listed APIs used by your app’s code to upload a new or updated app to App Store Connect.
...
> Make sure to use a version of the SDK that includes its privacy manifest and note that signatures are also required when the SDK is added as a binary dependency.
[Privacy updates for App Store submissions - Latest News - Apple Developer](https://developer.apple.com/news/?id=3d8a9yyh)
[Upcoming third-party SDK requirements - Support - Apple Developer](https://developer.apple.com/support/third-party-SDK-requirements/)