### PR TITLE
🔧 chore(pubspec): set timezone to ^0.11.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.16.0
-  timezone: ^0.9.0
+  timezone: ^0.11.1
   rrule: ^0.2.15
 
 dev_dependencies:


### PR DESCRIPTION
Resolve merge conflict in pubspec.yaml by removing conflict markers and updating the timezone dependency to ^0.11.1; keep other dependencies unchanged.